### PR TITLE
Quickfix for deprecated @rx.cached_var

### DIFF
--- a/custom_components/reflex_local_auth/local_auth.py
+++ b/custom_components/reflex_local_auth/local_auth.py
@@ -18,13 +18,14 @@ from .user import LocalUser
 
 AUTH_TOKEN_LOCAL_STORAGE_KEY = "_auth_token"
 DEFAULT_AUTH_SESSION_EXPIRATION_DELTA = datetime.timedelta(days=7)
+DEFAULT_AUTH_REFRESH_DELTA = datetime.timedelta(minutes=10)
 
 
 class LocalAuthState(rx.State):
     # The auth_token is stored in local storage to persist across tab and browser sessions.
     auth_token: str = rx.LocalStorage(name=AUTH_TOKEN_LOCAL_STORAGE_KEY)
 
-    @rx.cached_var
+    @rx.var(cache=True, interval=DEFAULT_AUTH_REFRESH_DELTA)
     def authenticated_user(self) -> LocalUser:
         """The currently authenticated user, or a dummy user if not authenticated.
 
@@ -46,7 +47,7 @@ class LocalAuthState(rx.State):
                 return user
         return LocalUser(id=-1)  # type: ignore
 
-    @rx.cached_var
+    @rx.var(cache=True, interval=DEFAULT_AUTH_REFRESH_DELTA)
     def is_authenticated(self) -> bool:
         """Whether the current user is authenticated.
 

--- a/local_auth_demo/local_auth_demo/custom_user_info.py
+++ b/local_auth_demo/local_auth_demo/custom_user_info.py
@@ -14,7 +14,7 @@ class UserInfo(rx.Model, table=True):
 
 
 class MyLocalAuthState(reflex_local_auth.LocalAuthState):
-    @rx.cached_var
+    @rx.var(cache=True)
     def authenticated_user_info(self) -> Optional[UserInfo]:
         if self.authenticated_user.id < 0:
             return


### PR DESCRIPTION
`@rx.cached_var` has been deprecated in [reflex v0.5.6 ](https://github.com/reflex-dev/reflex/releases/tag/v0.5.6)

Changes:
- Updated `LocalAuthState` and local demo to use `@rx.var(cache=True)`.
- Add a refresh interval of 10 minutes for cached variables



