### PR TITLE
reflex-local-auth 0.2.2 depends on reflex>=0.5.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reflex-local-auth"
-version = "0.2.1"
+version = "0.2.2"
 description = "Local DB user authentication for Reflex apps"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -18,7 +18,7 @@ keywords = [
     "reflex-custom-components"]
 
 dependencies = [
-    "reflex>=0.5.0",
+    "reflex>=0.5.9",
     "bcrypt",
 ]
 


### PR DESCRIPTION
In reflex-local-auth 0.2.2, @rx.cached_var has been replaced with @rx.var(cache=True), which before 0.5.9 had a bug where the initial value was not calculated. So to use this construct, we must bump the minimum version of reflex ot avoid the bug.