### PR TITLE
fix(database): specify field lengths for SQL Server compatibility

### DIFF
--- a/custom_components/reflex_local_auth/auth_session.py
+++ b/custom_components/reflex_local_auth/auth_session.py
@@ -1,6 +1,6 @@
 import datetime
 
-from sqlmodel import Column, DateTime, Field, func
+from sqlmodel import Column, DateTime, Field, func, String
 
 import reflex as rx
 
@@ -12,7 +12,7 @@ class LocalAuthSession(
     """Correlate a session_id with an arbitrary user_id."""
 
     user_id: int = Field(index=True, nullable=False)
-    session_id: str = Field(unique=True, index=True, nullable=False)
+    session_id: str = Field(unique=True, index=True, nullable=False, sa_type=String(255))
     expiration: datetime.datetime = Field(
         sa_column=Column(
             DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/custom_components/reflex_local_auth/user.py
+++ b/custom_components/reflex_local_auth/user.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import bcrypt
-from sqlmodel import Field
+from sqlmodel import Field, String
 
 import reflex as rx
 
@@ -12,7 +12,7 @@ class LocalUser(
 ):
     """A local User model with bcrypt password hashing."""
 
-    username: str = Field(unique=True, nullable=False, index=True)
+    username: str = Field(unique=True, nullable=False, index=True, sa_type=String(255))
     password_hash: bytes = Field(nullable=False)
     enabled: bool = False
 


### PR DESCRIPTION
- Add explicit field lengths to indexed string fields
- Update LocalUser model to use sa_type=String(255) for username field
- Update LocalAuthSession model to use sa_type=String(255) for session_id field
- Ensure compatibility with SQL Server schema creation

This change addresses issues with creating the schema in SQL Server due to undefined field lengths for indexed string columns.

Tested and verified on:
- Azure SQL Server
- SQL Server 2022 on-premise
- SQL Server 2019 on-premise
- SQLite

Thanks to [mistamun](https://forum.reflex.dev/u/mistamun)
 (Pedro Neto).