### PR TITLE
Solving reflex deprecation warnings (see issue #20)

### DIFF
--- a/custom_components/reflex_local_auth/login.py
+++ b/custom_components/reflex_local_auth/login.py
@@ -56,11 +56,11 @@ class LoginState(LocalAuthState):
         if not self.is_hydrated:
             # wait until after hydration to ensure auth_token is known
             return LoginState.redir()  # type: ignore
-        page = self.router.page.path
-        if not self.is_authenticated and page != routes.LOGIN_ROUTE:
-            self.redirect_to = self.router.page.raw_path
+        current_route = self.router.url.path
+        if not self.is_authenticated and current_route != routes.LOGIN_ROUTE:
+            self.redirect_to = current_route
             return rx.redirect(routes.LOGIN_ROUTE)
-        elif self.is_authenticated and page == routes.LOGIN_ROUTE:
+        elif self.is_authenticated and current_route == routes.LOGIN_ROUTE:
             return rx.redirect(self.redirect_to or "/")
 
 


### PR DESCRIPTION
rx.State.router.page is deprecated and will be removed in reflex v9.0

These changes tackle (at least a part of) the issue.